### PR TITLE
Add Privacy Pass activity summary.

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -90,6 +90,14 @@
             "topic": "MASQUE Working Group summary"
         }
     },
+    "privacy-pass@ietf.org": {
+        "digest:sunday": {
+            "repos": [
+                "ietf-wg-privacypass/base-drafts"
+            ],
+            "topic": "Privacy Pass Working Group summary"
+        }
+    },
     "mops@ietf.org": {
         "digest:sunday": {
             "eventFilter": {


### PR DESCRIPTION
This WG tracks work in a base-drafts repository like QUIC, so this should suffice for now.

cc @bemasc