### PR TITLE
Add CCWG repo rfc5033bis

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -392,5 +392,13 @@
             ],
             "topic": "WEBTRANS Working Group GitHub Activity Summary"
         }
+    },
+    "ccwg@ietf.org": {
+        "digest:sunday": {
+            "repos": [
+                "ietf-wg-ccwg/rfc5033bis"
+            ],
+            "topic": "CCWG GitHub Activity Summary"
+        }
     }
 }


### PR DESCRIPTION
We promised CCWG to send weekly digests [at IETF 117](https://datatracker.ietf.org/meeting/117/materials/slides-117-ccwg-chair-slides-02) and there was no objection, so let's do it and see what people think. :slightly_smiling_face: 