### PR TITLE
Move WIMSE draft

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -609,7 +609,7 @@
                 ]
             },
             "repos": [
-                "ietf-wg-wimse/draft-ietf-wimse-workload-identity-bcp",
+                "ietf-wg-wimse/draft-ietf-wimse-workload-identity-practices",
                 "ietf-wg-wimse/draft-ietf-wimse-arch",
                 "ietf-wg-wimse/draft-ietf-wimse-s2s-protocol"
             ],


### PR DESCRIPTION
One of the WIMSE draft repositories was moved from `draft-ietf-wimse-workload-identity-bcp` to `draft-ietf-wimse-workload-identity-practices`, this aligns the configuration.