### PR TITLE
Add automation-keyusages repo to the tracker

### DIFF
--- a/mls.json
+++ b/mls.json
@@ -711,6 +711,7 @@
 	    },
 	    "repos": [
 		"lamps-wg/8410-ku-clarifications",
+		"lamps-wg/automation-keyusages",
 		"lamps-wg/cmcbis",
 		"lamps-wg/cmp-updates",
 		"lamps-wg/cms-kemri",


### PR DESCRIPTION
There's a new draft focused on adding new key usage options to certificates, I add it here so it can be featured in the regular digests.